### PR TITLE
Add GitHub Action for automated Flux distro updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ comes with enterprise-hardened Flux controllers including:
 - Assured compatibility with OpenShift and Kubernetes LTS versions provided by cloud vendors.
 
 The ControlPlane distribution is offered on a
-[yearly subscription basis](https://control-plane.io/enterprise-flux/) and includes
+[yearly subscription basis](https://control-plane.io/enterprise-for-flux-cd/) and includes
 enterprise-grade support services for running Flux in production.
 
 > [!TIP]
@@ -53,6 +53,66 @@ images fully compatible with the upstream Flux feature set.
 The major difference between the Flux upstream images and mainline images is the
 continuous scanning and CVE patching for the container base images, OS packages,
 and Go dependencies.
+
+## Installation and Upgrades
+
+ControlPlane offers a seamless transition from CNCF Flux to the enterprise distribution with no
+impact to Flux availability. The hardened container images provided by ControlPlane are fully
+compatible with the upstream Flux installation and bootstrap procedure.
+
+Customers can bootstrap Flux with the enterprise distribution using the Flux CLI or the Flux Terraform provider.
+To access the ControlPlane registry, customers need to provide their credentials using the
+`--registry-cred` flag.
+
+Example of bootstrapping Flux with the FIPS-compliant distribution:
+
+```bash
+flux bootstrap github \
+  --owner=customer-org \
+  --repository=customer-repo \
+  --branch=main \
+  --path=./clusters/production \
+  --image-pull-secret=flux-enterprise-auth \
+  --registry-cred=flux:$ENTERPRISE_TOKEN \
+  --registry=ghcr.io/controlplaneio-fluxcd/distroless
+```
+
+### Automated Updates
+
+For keeping the Flux controllers images digests
+and manifests up-to-date with the latest version of the Enterprise Distribution, ControlPlane
+provides Kustomize images patches for the Flux manifests, which can be found in the
+[distribution repository](https://github.com/controlplaneio-fluxcd/distribution/tree/main/images).
+
+Customers using GitHub can leverage the ControlPlane GitHub Actions to automate the
+update of the Flux manifests in their bootstrap repositories. For more information, see the
+[Update Flux GitHub Action](actions/update/README.md) documentation.
+
+For customers using other Git providers, ControlPlane provides support for configuring
+automated updates for the Flux enterprise distribution.
+
+## Guides and Documentation
+
+The ControlPlane distribution comes with a set of guides and documentation to help customers
+configure and operate the Flux controllers in production environments.
+
+### Flux Architecture Overview
+
+The [Flux CD Architecture Overview](https://control-plane.io/posts/fluxcd-architecture-overview/)
+guide provides a comprehensive overview of the Flux CD architectures, including a
+comparison of the deployment strategies of the Flux components when implementing GitOps
+for multi-cluster continuous delivery.
+
+### Flux d1 Reference Architecture
+
+The aim of this guide is to provide a comprehensive description of the Flux d1 reference
+architecture, offered by the d1 repositories housed within the controlplaneio-fluxcd organization.
+These repositories and the [flux d1 reference architecture guide](/guides/ControlPlane_Flux_D1_Reference_Architecture_Guide.pdf) expand upon the
+established Flux documentation, which includes a quickstart guide for orchestrating a single cluster.
+Our focus is to showcase how Flux can address the requirements of organizations managing
+multiple teams deploying applications across numerous multi-tenant Kubernetes clusters using Flux.
+Through this comprehensive resource, users can gain insights into leveraging Flux
+for streamlined multi-cluster management and efficient application deployment workflows.
 
 ## Supply Chain Security
 
@@ -114,47 +174,3 @@ cosign verify-attestation --type slsaprovenance \
   <registry>/source-controller:v1.3.0
 ```
 
-## Installation and Upgrades
-
-ControlPlane offers a seamless transition between CNCF Flux to the enterprise distribution with no
-impact to Flux availability. The hardened container images provided by ControlPlane are fully
-compatible with the upstream Flux installation and bootstrap procedure.
-
-Customers can bootstrap Flux with the enterprise distribution using the Flux CLI or the Flux TF provider.
-To access the ControlPlane registry, customers need to provide their credentials using the
-`--registry-cred` flag.
-
-Example of bootstrapping Flux with the FIPS-compliant distribution:
-
-```bash
-flux bootstrap github \
-  --owner=customer-org \
-  --repository=customer-repo \
-  --branch=main \
-  --path=./clusters/production \
-  --image-pull-secret=flux-enterprise-auth \
-  --registry-cred=flux:$ENTERPRISE_TOKEN \
-  --registry=ghcr.io/controlplaneio-fluxcd/distroless
-```
-
-For keeping the Flux controllers images digests
-and manifests up-to-date with the latest version of the Enterprise Distribution, ControlPlane
-provides Kustomize images patches for the Flux manifests, which can be found in the
-[distribution repository](https://github.com/controlplaneio-fluxcd/distribution/tree/main/images).
-We provide support for configuring automated updates of the Flux manifests in bootstrap repositories.
-
-## Guides and Documentation
-
-The ControlPlane distribution comes with a set of guides and documentation to help customers
-configure and operate the Flux controllers in production environments.
-
-### Flux d1 Reference Architecture
-
-The aim of this guide is to provide a comprehensive description of the Flux d1 reference 
-architecture, offered by the d1 repositories housed within the controlplaneio-fluxcd organization.
-These repositories and the [flux d1 reference architecture guide](/guides/ControlPlane_Flux_D1_Reference_Architecture_Guide.pdf) expand upon the 
-established Flux documentation, which includes a quickstart guide for orchestrating a single cluster.
-Our focus is to showcase how Flux can address the requirements of organizations managing
-multiple teams deploying applications across numerous multi-tenant Kubernetes clusters using Flux.
-Through this comprehensive resource, users can gain insights into leveraging Flux 
-for streamlined multi-cluster management and efficient application deployment workflows.

--- a/actions/update/README.md
+++ b/actions/update/README.md
@@ -36,7 +36,6 @@ jobs:
           image-pull-secret: flux-enterprise-auth
           registry: ghcr.io/controlplaneio-fluxcd
           variant: distroless
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
@@ -55,12 +54,11 @@ when new versions of the Enterprise Distribution are available.
 
 ## Action Inputs
 
-| Name                | Description                                                                             | Default                                                                                                                                 |
-|---------------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `path`              | Path to the flux-system dir e.g. `clusters/production/flux-system/`                     |                                                                                                                                         |
-| `registry`          | Container Registry Address                                                              | `ghcr.io/controlplaneio-fluxcd`                                                                                                         |
-| `variant`           | Base image OS e.g. `alpine` or `distroless`                                             | `alpine`                                                                                                                                |
-| `image-pull-secret` | Name of the Enterprise Kubernetes image pull secret                                     | `flux-enterprise-auth`                                                                                                                  |
-| `components`        | Flux components comma separated list                                                    | `source-controller,kustomize-controller,notification-controller,helm-controller,image-automation-controller,image-reflector-controller` |
-| `token`             | Token used to authentication against the GitHub.com API to query for the latest version | `github.token`                                                                                                                          |
-| `bindir`            | Alternative location for the Flux binary                                                | `$RUNNER_TOOL_CACHE`                                                                                                                    |
+| Name                | Description                                                         | Default                                                                                                                                 |
+|---------------------|---------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `path`              | Path to the flux-system dir e.g. `clusters/production/flux-system/` |                                                                                                                                         |
+| `registry`          | Container Registry Address                                          | `ghcr.io/controlplaneio-fluxcd`                                                                                                         |
+| `variant`           | Base image OS e.g. `alpine` or `distroless`                         | `alpine`                                                                                                                                |
+| `image-pull-secret` | Name of the Kubernetes image pull secret                            | `flux-enterprise-auth`                                                                                                                  |
+| `components`        | Flux components comma separated list                                | `source-controller,kustomize-controller,helm-controller,notification-controller,image-reflector-controller,image-automation-controller` |
+| `bindir`            | Alternative location for the Flux CLI binary                        | `$RUNNER_TOOL_CACHE`                                                                                                                    |

--- a/actions/update/README.md
+++ b/actions/update/README.md
@@ -1,0 +1,56 @@
+# Update Flux GitHub Action
+
+This GitHub Action can be used to automate the update of the
+Enterprise Distribution for Flux CD on clusters via Pull Requests.
+
+## Usage
+
+Example workflow for keeping the Flux controllers images digests
+and manifests up-to-date with the latest version of the Enterprise Distribution:
+
+```yaml
+name: Update Enterprise Distribution for Flux CD
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 7 * * 1-5'
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update manifests
+        id: update
+        uses: controlplaneio-fluxcd/distribution/actions/update@main
+        with:
+          path: clusters/production/flux-system
+          image-pull-secret: flux-enterprise-auth
+          registry: ghcr.io/controlplaneio-fluxcd
+          variant: distroless
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-flux-${{ steps.update.outputs.version }}
+          commit-message: |
+            Update manifests and image digests for Flux ${{ steps.update.outputs.version }}
+          title: Update Flux to ${{ steps.update.outputs.version }}
+          body: |
+            Update manifests and image digests for Flux ${{ steps.update.outputs.version }}
+```
+
+The above example will run the workflow every Monday to Friday at 7am UTC,
+and will create a Pull Request for the Flux manifests under `clusters/production/flux-system`
+when new versions of the Enterprise Distribution are available.
+
+

--- a/actions/update/README.md
+++ b/actions/update/README.md
@@ -1,7 +1,8 @@
 # Update Flux GitHub Action
 
 This GitHub Action can be used to automate the update of the
-Enterprise Distribution for Flux CD on clusters via Pull Requests.
+[Enterprise Distribution](https://control-plane.io/enterprise-for-flux-cd/)
+for Flux CD on clusters via Pull Requests.
 
 ## Usage
 

--- a/actions/update/README.md
+++ b/actions/update/README.md
@@ -53,4 +53,14 @@ The above example will run the workflow every Monday to Friday at 7am UTC,
 and will create a Pull Request for the Flux manifests under `clusters/production/flux-system`
 when new versions of the Enterprise Distribution are available.
 
+## Action Inputs
 
+| Name                | Description                                                                             | Default                                                                                                                                 |
+|---------------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `path`              | Path to the flux-system dir e.g. `clusters/production/flux-system/`                     |                                                                                                                                         |
+| `registry`          | Container Registry Address                                                              | `ghcr.io/controlplaneio-fluxcd`                                                                                                         |
+| `variant`           | Base image OS e.g. `alpine` or `distroless`                                             | `alpine`                                                                                                                                |
+| `image-pull-secret` | Name of the Enterprise Kubernetes image pull secret                                     | `flux-enterprise-auth`                                                                                                                  |
+| `components`        | Flux components comma separated list                                                    | `source-controller,kustomize-controller,notification-controller,helm-controller,image-automation-controller,image-reflector-controller` |
+| `token`             | Token used to authentication against the GitHub.com API to query for the latest version | `github.token`                                                                                                                          |
+| `bindir`            | Alternative location for the Flux binary                                                | `$RUNNER_TOOL_CACHE`                                                                                                                    |

--- a/actions/update/action.yaml
+++ b/actions/update/action.yaml
@@ -1,0 +1,154 @@
+name: Update Flux manifests
+description: A GitHub Action for updating Flux manifests in bootstrap repositories
+author: Stefan Prodan
+branding:
+  color: blue
+  icon: command
+inputs:
+  registry:
+    description: "Enterprise Container Registry"
+    default: "ghcr.io/controlplaneio-fluxcd"
+    required: true
+  variant:
+    description: "Base image variant e.g. alpine or distroless"
+    required: true
+  components:
+    description: "Flux components comma separated list e.g. source-controller,kustomize-controller"
+    default: "source-controller,kustomize-controller,notification-controller,helm-controller,image-automation-controller,image-reflector-controller"
+    required: true
+  path:
+    description: "Path to the flux-system dir e.g. clusters/production/flux-system/"
+    required: true
+  image-pull-secret:
+    description: "Name of the Enterprise Kubernetes image pull secret"
+    default: "flux-enterprise-auth"
+    required: true
+  version:
+    description: "Flux version e.g. 2.2.0 (defaults to latest stable release)"
+    required: false
+  bindir:
+    description: "Alternative location for the Flux binary, defaults to path relative to $RUNNER_TOOL_CACHE."
+    required: false
+  token:
+    description: "Token used to authentication against the GitHub.com API. Defaults to the token from the GitHub context of the workflow."
+    required: false
+outputs:
+  version:
+    description: "Flux version"
+    value: ${{ steps.cli.outputs.version }}
+runs:
+  using: composite
+  steps:
+    - name: "Download the binary to the runner's cache dir"
+      id: cli
+      shell: bash
+      run: |
+        VERSION=${{ inputs.version }}
+
+        TOKEN=${{ inputs.token }}
+        if [[ -z "$TOKEN" ]]; then
+          TOKEN=${{ github.token }}
+        fi
+
+        if [[ -z "$VERSION" ]] || [[ "$VERSION" = "latest" ]]; then
+          VERSION=$(curl -fsSL -H "Authorization: token ${TOKEN}" https://api.github.com/repos/controlplaneio-fluxcd/distribution/releases/latest | grep tag_name | cut -d '"' -f 4)
+        fi
+        if [[ -z "$VERSION" ]]; then
+          echo "Unable to determine Flux CLI version"
+          exit 1
+        fi
+        if [[ $VERSION = v* ]]; then
+          VERSION="${VERSION:1}"
+        fi
+
+        OS=$(echo "${RUNNER_OS}" | tr '[:upper:]' '[:lower:]')
+        if [[ "$OS" == "macos" ]]; then
+          OS="darwin"
+        fi
+
+        ARCH=$(echo "${RUNNER_ARCH}" | tr '[:upper:]' '[:lower:]')
+        if [[ "$ARCH" == "x64" ]]; then
+          ARCH="amd64"
+        elif [[ "$ARCH" == "x86" ]]; then
+          ARCH="386"
+        fi
+
+        FLUX_EXEC_FILE="flux"
+        if [[ "$OS" == "windows" ]]; then
+            FLUX_EXEC_FILE="${FLUX_EXEC_FILE}.exe"
+        fi
+
+        FLUX_TOOL_DIR=${{ inputs.bindir }}
+        if [[ -z "$FLUX_TOOL_DIR" ]]; then
+          FLUX_TOOL_DIR="${RUNNER_TOOL_CACHE}/flux2/${VERSION}/${OS}/${ARCH}"
+        fi
+        if [[ ! -x "$FLUX_TOOL_DIR/FLUX_EXEC_FILE" ]]; then
+          DL_DIR="$(mktemp -dt flux2-XXXXXX)"
+          trap 'rm -rf $DL_DIR' EXIT
+
+          echo "Downloading flux ${VERSION} for ${OS}/${ARCH}"
+          FLUX_TARGET_FILE="flux_${VERSION}_${OS}_${ARCH}.tar.gz"
+          if [[ "$OS" == "windows" ]]; then
+            FLUX_TARGET_FILE="flux_${VERSION}_${OS}_${ARCH}.zip"
+          fi
+
+          FLUX_CHECKSUMS_FILE="flux_${VERSION}_checksums.txt"
+
+          FLUX_DOWNLOAD_URL="https://github.com/fluxcd/flux2/releases/download/v${VERSION}/"
+
+          curl -fsSL -o "$DL_DIR/$FLUX_TARGET_FILE" "$FLUX_DOWNLOAD_URL/$FLUX_TARGET_FILE"
+          curl -fsSL -o "$DL_DIR/$FLUX_CHECKSUMS_FILE" "$FLUX_DOWNLOAD_URL/$FLUX_CHECKSUMS_FILE"
+
+          echo "Verifying checksum"
+          sum=""
+          if command -v openssl > /dev/null; then
+            sum=$(openssl sha256 "$DL_DIR/$FLUX_TARGET_FILE" | awk '{print $2}')
+          elif command -v sha256sum > /dev/null; then
+            sum=$(sha256sum "$DL_DIR/$FLUX_TARGET_FILE" | awk '{print $1}')
+          fi
+
+          if [[ -z "$sum" ]]; then
+            echo "Neither openssl nor sha256sum found. Cannot calculate checksum."
+            exit 1
+          fi
+
+          expected_sum=$(grep " $FLUX_TARGET_FILE\$" "$DL_DIR/$FLUX_CHECKSUMS_FILE" | awk '{print $1}')
+          if [ "$sum" != "$expected_sum" ]; then
+            echo "SHA sum of ${FLUX_TARGET_FILE} does not match. Aborting."
+            exit 1
+          fi
+
+          echo "Installing flux to ${FLUX_TOOL_DIR}"
+          mkdir -p "$FLUX_TOOL_DIR"
+        
+          if [[ "$OS" == "windows" ]]; then
+            unzip "$DL_DIR/$FLUX_TARGET_FILE" "$FLUX_EXEC_FILE" -d "$FLUX_TOOL_DIR"
+          else
+            tar xzf "$DL_DIR/$FLUX_TARGET_FILE" -C "$FLUX_TOOL_DIR" $FLUX_EXEC_FILE
+          fi
+
+          chmod +x "$FLUX_TOOL_DIR/$FLUX_EXEC_FILE"
+        fi
+
+        echo "Adding flux to path"
+        echo "$FLUX_TOOL_DIR" >> "$GITHUB_PATH"
+        echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
+    - name: "Update components manifests"
+      shell: bash
+      run: |
+        cd ${{ inputs.path }}
+        flux install \
+        --components="${{ inputs.components }}" \
+        --registry=${{ inputs.registry }}/${{ inputs.variant }} \
+        --image-pull-secret=${{ inputs.image-pull-secret }} \
+        --export > gotk-components.yaml
+    - name: "Update images digests"
+      shell: bash
+      run: |
+        cd ${{ inputs.path }}
+        version=$(flux -v | awk '{ print $3 }')
+        base_url="https://raw.githubusercontent.com/controlplaneio-fluxcd/distribution/main/images"
+        curl -fsSL -o enterprise-images.yaml ${base_url}/v${version}/enterprise-${{ inputs.variant }}.yaml
+        yq '. *= load("enterprise-images.yaml")' kustomization.yaml > kustomization.yaml.tmp
+        mv kustomization.yaml.tmp kustomization.yaml
+        rm enterprise-images.yaml

--- a/actions/update/action.yaml
+++ b/actions/update/action.yaml
@@ -6,7 +6,7 @@ branding:
   icon: command
 inputs:
   registry:
-    description: "Enterprise Container Registry"
+    description: "Distribution Container Registry"
     default: "ghcr.io/controlplaneio-fluxcd"
     required: true
   variant:
@@ -15,23 +15,24 @@ inputs:
     required: true
   components:
     description: "Flux components comma separated list e.g. source-controller,kustomize-controller"
-    default: "source-controller,kustomize-controller,notification-controller,helm-controller,image-automation-controller,image-reflector-controller"
+    default: "source-controller,kustomize-controller,helm-controller,notification-controller,image-reflector-controller,image-automation-controller"
     required: true
   path:
     description: "Path to the flux-system dir e.g. clusters/production/flux-system/"
     required: true
   image-pull-secret:
-    description: "Name of the Enterprise Kubernetes image pull secret"
+    description: "Name of the Kubernetes image pull secret for accessing the distribution registry"
     default: "flux-enterprise-auth"
     required: true
   version:
-    description: "Flux version e.g. 2.2.0 (defaults to latest stable release)"
+    description: "Distribution version e.g. v2.2.0 (defaults to latest stable release)"
     required: false
   bindir:
     description: "Alternative location for the Flux binary, defaults to path relative to $RUNNER_TOOL_CACHE."
     required: false
-  token:
-    description: "Token used to authentication against the GitHub.com API. Defaults to the token from the GitHub context of the workflow."
+  distribution-url:
+    description: "Distribution images info URL"
+    default: "https://raw.githubusercontent.com/controlplaneio-fluxcd/distribution/main/images"
     required: false
 outputs:
   version:
@@ -40,22 +41,17 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: "Download the binary to the runner's cache dir"
+    - name: "Download the Flux CLI binary to the runner's cache dir"
       id: cli
       shell: bash
       run: |
         VERSION=${{ inputs.version }}
 
-        TOKEN=${{ inputs.token }}
-        if [[ -z "$TOKEN" ]]; then
-          TOKEN=${{ github.token }}
-        fi
-
         if [[ -z "$VERSION" ]] || [[ "$VERSION" = "latest" ]]; then
-          VERSION=$(curl -fsSL -H "Authorization: token ${TOKEN}" https://api.github.com/repos/controlplaneio-fluxcd/distribution/releases/latest | grep tag_name | cut -d '"' -f 4)
+          VERSION=$(curl -fsSL ${{ inputs.distribution-url }}/VERSION | head -n1)
         fi
         if [[ -z "$VERSION" ]]; then
-          echo "Unable to determine Flux CLI version"
+          echo "Unable to determine the latest distribution version"
           exit 1
         fi
         if [[ $VERSION = v* ]]; then
@@ -148,8 +144,8 @@ runs:
       run: |
         cd ${{ inputs.path }}
         version=$(flux -v | awk '{ print $3 }')
-        base_url="https://raw.githubusercontent.com/controlplaneio-fluxcd/distribution/main/images"
-        curl -fsSL -o enterprise-images.yaml ${base_url}/v${version}/enterprise-${{ inputs.variant }}.yaml
+        images_url="${{ inputs.distribution-url }}/v${version}/enterprise-${{ inputs.variant }}.yaml"
+        curl -fsSL -o enterprise-images.yaml ${images_url}
         yq '. *= load("enterprise-images.yaml")' kustomization.yaml > kustomization.yaml.tmp
         mv kustomization.yaml.tmp kustomization.yaml
         rm enterprise-images.yaml

--- a/actions/update/action.yaml
+++ b/actions/update/action.yaml
@@ -22,8 +22,7 @@ inputs:
     required: true
   image-pull-secret:
     description: "Name of the Kubernetes image pull secret for accessing the distribution registry"
-    default: "flux-enterprise-auth"
-    required: true
+    required: false
   version:
     description: "Distribution version e.g. v2.2.0 (defaults to latest stable release)"
     required: false
@@ -133,11 +132,11 @@ runs:
     - name: "Update components manifests"
       shell: bash
       run: |
-        cd ${{ inputs.path }}
         registry=${{ inputs.registry }}
         if [[ "${{ inputs.registry }}" == "ghcr.io/controlplaneio-fluxcd" ]]; then
           registry=${{ inputs.registry }}/${{ inputs.variant }}
         fi
+        cd ${{ inputs.path }}
         flux install \
         --components="${{ inputs.components }}" \
         --registry=${registry} \
@@ -146,12 +145,12 @@ runs:
     - name: "Update images digests"
       shell: bash
       run: |
+        if [[ "${{ inputs.registry }}" != "ghcr.io/controlplaneio-fluxcd" ]]; then
+          exit 0
+        fi
         cd ${{ inputs.path }}
         version=$(flux -v | awk '{ print $3 }')
-        images_url="${{ inputs.distribution-url }}/v${version}/upstream-${{ inputs.variant }}.yaml"
-        if [[ "${{ inputs.registry }}" == "ghcr.io/controlplaneio-fluxcd" ]]; then
-          images_url="${{ inputs.distribution-url }}/v${version}/enterprise-${{ inputs.variant }}.yaml"
-        fi
+        images_url="${{ inputs.distribution-url }}/v${version}/enterprise-${{ inputs.variant }}.yaml"
         curl -fsSL -o enterprise-images.yaml ${images_url}
         yq '. *= load("enterprise-images.yaml")' kustomization.yaml > kustomization.yaml.tmp
         mv kustomization.yaml.tmp kustomization.yaml

--- a/actions/update/action.yaml
+++ b/actions/update/action.yaml
@@ -11,6 +11,7 @@ inputs:
     required: true
   variant:
     description: "Base image variant e.g. alpine or distroless"
+    default: "alpine"
     required: true
   components:
     description: "Flux components comma separated list e.g. source-controller,kustomize-controller"

--- a/actions/update/action.yaml
+++ b/actions/update/action.yaml
@@ -134,9 +134,13 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.path }}
+        registry=${{ inputs.registry }}
+        if [[ "${{ inputs.registry }}" == "ghcr.io/controlplaneio-fluxcd" ]]; then
+          registry=${{ inputs.registry }}/${{ inputs.variant }}
+        fi
         flux install \
         --components="${{ inputs.components }}" \
-        --registry=${{ inputs.registry }}/${{ inputs.variant }} \
+        --registry=${registry} \
         --image-pull-secret=${{ inputs.image-pull-secret }} \
         --export > gotk-components.yaml
     - name: "Update images digests"
@@ -144,7 +148,10 @@ runs:
       run: |
         cd ${{ inputs.path }}
         version=$(flux -v | awk '{ print $3 }')
-        images_url="${{ inputs.distribution-url }}/v${version}/enterprise-${{ inputs.variant }}.yaml"
+        images_url="${{ inputs.distribution-url }}/v${version}/upstream-${{ inputs.variant }}.yaml"
+        if [[ "${{ inputs.registry }}" == "ghcr.io/controlplaneio-fluxcd" ]]; then
+          images_url="${{ inputs.distribution-url }}/v${version}/enterprise-${{ inputs.variant }}.yaml"
+        fi
         curl -fsSL -o enterprise-images.yaml ${images_url}
         yq '. *= load("enterprise-images.yaml")' kustomization.yaml > kustomization.yaml.tmp
         mv kustomization.yaml.tmp kustomization.yaml


### PR DESCRIPTION
This PR adds a GitHub Action for keeping the Flux controllers images digests and manifests up-to-date with the
latest version of the Enterprise Distribution.

Using this action ensures that every time we publish new images with CVE fixes, the images digests are updated in the `flux-system` kustomization and Flux running on clusters will upgrade itself with the new images.

Example of a PR updating the Flux controllers images digests from v2.2.2 to v2.2.3 

![flux-distro-update](https://github.com/controlplaneio-fluxcd/distribution/assets/3797675/2ed9eae5-2500-48c4-9819-6263dee35c05)
