### PR TITLE
Enterprise Distribution for Flux AIO

### DIFF
--- a/flux-aio/README.md
+++ b/flux-aio/README.md
@@ -1,0 +1,35 @@
+# Enterprise Distribution for Flux AIO
+
+Flux All-In-One is a lightweight Flux CD distribution made with [Timoni](https://timoni.sh)
+for running the GitOps Toolkit controllers as a single deployable unit.
+
+This distribution is optimized for running Flux on:
+
+- Edge clusters with limited CPU and memory resources
+- Bare clusters without a CNI plugin installed
+- Clusters where plain HTTP communication is not allowed between pods
+- Serverless clusters for cost optimisation (EKS Fargate, GKE Autopilot)
+
+## Installation
+
+To deploy the enterprise version of Flux AIO, run the following commands:
+
+```shell
+gh repo clone controlplaneio-fluxcd/distribution
+cd distribution/flux-aio/bundles
+
+TOKEN=<SUBSCRIPTION TOKEN> timoni bundle apply -f flux-aio.cue --runtime-from-env
+```
+
+The above command will install the enterprise version of Flux AIO in
+the `flux-system` namespace and configure the Flux controllers to use the
+FIPS-compliant container images.
+
+## Documentation
+
+To find out more about Flux AIO, see the following documentation:
+
+- [Flux AIO specifications](https://timoni.sh/flux-aio/#specifications)
+- [Flux installation](https://timoni.sh/flux-aio/#flux-installation)
+- [Flux Git sync configuration](https://timoni.sh/flux-aio/#flux-git-sync-configuration)
+- [Flux multi-tenancy configuration](https://timoni.sh/flux-aio/#flux-multi-tenancy-configuration)

--- a/flux-aio/bundles/flux-aio.cue
+++ b/flux-aio/bundles/flux-aio.cue
@@ -1,0 +1,51 @@
+// Flux AIO bundle
+// Documentation: https://timoni.sh/flux-aio/
+bundle: {
+	apiVersion: "v1alpha1"
+	name:       "flux-aio"
+
+	// Enterprise distribution settings
+	_distribution: {
+		// Container registry image pull token
+		token: string @timoni(runtime:string:TOKEN)
+		// Container registry address
+		registry: "ghcr.io/controlplaneio-fluxcd/distroless" @timoni(runtime:string:REGISTRY)
+		// Flux AIO version e.g. 2.2.3-0
+		// To list available versions run:
+		// timoni mod ls oci://ghcr.io/stefanprodan/modules/flux-aio
+		version: "latest" @timoni(runtime:string:VERSION)
+	}
+
+	instances: {
+		"flux": {
+			module: {
+				url:     "oci://ghcr.io/stefanprodan/modules/flux-aio"
+				version: _distribution.version
+			}
+			namespace: "flux-system"
+			values: {
+				controllers: {
+					source: image: {
+						repository: "\(_distribution.registry)/source-controller"
+					}
+					kustomize: image: {
+						repository: "\(_distribution.registry)/kustomize-controller"
+					}
+					notification: image: {
+						repository: "\(_distribution.registry)/notification-controller"
+					}
+					helm: image: {
+						repository: "\(_distribution.registry)/helm-controller"
+					}
+				}
+				imagePullSecret: {
+					registry: _distribution.registry
+					password: _distribution.token
+					username: "flux"
+				}
+				hostNetwork:     false
+				securityProfile: "privileged"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add Timoni bundle to deploy [Flux AIO](https://timoni.sh/flux-aio/) with the FIPS-compliant images.