### PR TITLE
Add CVE-2019-25210 to ignore list

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,7 @@
+# The vulnerabilities listed here have no affect on Flux
+# either because the vulnerable code paths are not used in Flux
+# or because the CVEs have been dismissed by upstream maintainers.
+
+# This CVE has been dismissed by the Helm team.
+# https://helm.sh/blog/response-cve-2019-25210/
+CVE-2019-25210


### PR DESCRIPTION
CVE-2019-25210 has been dismissed by the Helm team and the dry run functionality is not used in Flux.

Refs:
- https://helm.sh/blog/response-cve-2019-25210/
- https://github.com/helm/helm/issues/7275