### PR TITLE
Run EE conformance tests for Kubernetes v1.30.0

### DIFF
--- a/.github/workflows/e2e-fips.yaml
+++ b/.github/workflows/e2e-fips.yaml
@@ -15,12 +15,12 @@ jobs:
         variant:
           - distroless
         kubernetes:
-          - v1.24.7
-          - v1.25.11
-          - v1.26.6
-          - v1.27.3
-          - v1.28.0
-          - v1.29.0
+          - v1.24.17
+          - v1.25.16
+          - v1.26.14
+          - v1.27.11
+          - v1.28.7
+          - v1.29.2
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,7 +26,7 @@ jobs:
           - alpine
           - distroless
         kubernetes:
-          - v1.29.0
+          - v1.30.0
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,7 +61,7 @@ jobs:
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
         with:
           cluster_name: flux
-          node_image: kindest/node:${{ matrix.kubernetes }}
+          node_image: ghcr.io/fluxcd/kindest/node:${{ matrix.kubernetes }}-amd64
       - name: Install Flux
         id: install
         run: |


### PR DESCRIPTION
Changes:
- Update the Kubernetes version matrix in the FIPS tests
- Run conformance tests for Kubernetes v1.30.0 for all distros

Part of: #45