### PR TITLE
Update Kubernetes e2e test matrix

### DIFF
--- a/.github/workflows/e2e-fips.yaml
+++ b/.github/workflows/e2e-fips.yaml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - 'release-*'
+      - 'test-*'
     tags-ignore:
       - '*'
 
@@ -26,10 +27,11 @@ jobs:
         kubernetes:
           - v1.24.17
           - v1.25.16
-          - v1.26.14
-          - v1.27.11
-          - v1.28.7
-          - v1.29.2
+          - v1.26.15
+          - v1.27.13
+          - v1.28.9
+          - v1.29.4
+          - v1.30.0
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,6 +65,7 @@ jobs:
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
           cluster_name: flux
+          version: v0.23.0
           node_image: kindest/node:${{ matrix.kubernetes }}
       - name: Install Flux
         shell: bash

--- a/releases/release-v2.2.md
+++ b/releases/release-v2.2.md
@@ -1,5 +1,6 @@
 # Enterprise Distribution for Flux v2.2.x
 
+- [k8s](#supported-kubernetes-versions)
 - [apis](#api-versions)
   - [ga](#general-availability-ga)
   - [beta](#beta-preview)
@@ -16,6 +17,13 @@
 - [v2.2.0](#v220)
   - [mainline](#mainline-v220)
   - [FIPS-compliant](#fips-compliant-v220)
+
+## Supported Kubernetes Versions
+
+| Distribution | Versions                                          |
+|:-------------|:--------------------------------------------------|
+| Kubernetes   | 1.24 <br>1.25 <br>1.26 <br>1.27 <br>1.28 <br>1.29 |
+| OpenShift    | 4.12 <br>4.13 <br>4.14 <br>4.15                   |
 
 ## API Versions
 

--- a/releases/release-v2.3.md
+++ b/releases/release-v2.3.md
@@ -1,5 +1,6 @@
 # Enterprise Distribution for Flux v2.3.x
 
+- [k8s](#supported-kubernetes-versions)
 - [apis](#api-versions)
   - [ga](#general-availability-ga)
   - [beta](#beta-preview)
@@ -7,6 +8,13 @@
 - [v2.3.0](#v230)
   - [mainline](#mainline-v230)
   - [FIPS-compliant](#fips-compliant-v230)
+
+## Supported Kubernetes Versions
+
+| Distribution | Versions                                          |
+|:-------------|:--------------------------------------------------|
+| Kubernetes   | 1.25 <br>1.26 <br>1.27 <br>1.28 <br>1.29 <br>1.30 |
+| OpenShift    | 4.12 <br>4.13 <br>4.14 <br>4.15                   |
 
 ## API Versions
 


### PR DESCRIPTION
Changes:
- Update test matrix with the latest Kubernetes patch releases
- Add supported Kubernetes & OpenShift versions to release notes