### PR TITLE
Add OpenVEX documents for Flux EE releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ cosign verify <registry>/source-controller:v1.3.0 \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 ```
 
-### SLSA Provenance verification
+### SLSA Provenance Verification
 
 The provenance attestations are generated at build time with Docker Buildkit and
 include facts about the build process such as:
@@ -177,3 +177,34 @@ cosign verify-attestation --type slsaprovenance \
   <registry>/source-controller:v1.3.0
 ```
 
+### Vulnerability Exploitability eXchange
+
+The Flux controllers (source code, binaries and container images) are continuously
+scanned for CVEs. Once a CVE is detected, the ControlPlane team assesses
+the exploitability of the vulnerability. If the vulnerability is proven to be exploitable,
+the ControlPlane team provides a patch within the agreed SLA and issues
+a security bulletin to customers containing the CVE details and the container images
+digests that include the fix.
+
+There are cases where the vulnerability is not exploitable in the context of the Flux
+controllers, and in such cases, the ControlPlane team issues a CVE exception in the
+[OpenVEX](https://github.com/openvex/spec/blob/v0.2.0/OPENVEX-SPEC.md) format.
+
+For each Flux minor release, the ControlPlane team maintains a VEX document with the
+list of vulnerabilities that do not affect the Flux controllers. The VEX documents
+are available in the enterprise distribution repository under the `vex` directory.
+
+Example of scanning the source-controller image with [Trivy](https://github.com/aquasecurity/trivy)
+using the VEX document:
+
+```console
+$ trivy image <registry>/source-controller:v1.2.2 --vex ./vex/v2.2.json --show-suppressed
+
+Suppressed Vulnerabilities (Total: 1)
+
+┌─────────────────┬────────────────┬──────────┬──────────────┬─────────────────────────────┬─────────┐
+│     Library     │ Vulnerability  │ Severity │    Status    │          Statement          │ Source  │
+├─────────────────┼────────────────┼──────────┼──────────────┼─────────────────────────────┼─────────┤
+│ helm.sh/helm/v3 │ CVE-2019-25210 │ MEDIUM   │ not_affected │ vulnerable_code_not_present │ OpenVEX │
+└─────────────────┴────────────────┴──────────┴──────────────┴─────────────────────────────┴─────────┘
+```

--- a/vex/v2.2.json
+++ b/vex/v2.2.json
@@ -4,6 +4,36 @@
   "author": "flux-enterprise@control-plane.io",
   "role": "Enterprise Flux Maintainers",
   "timestamp": "2024-05-23T17:26:04.422544+03:00",
-  "version": 1,
-  "statements": []
+  "last_updated": "2024-05-24T00:38:58.404614+03:00",
+  "version": 3,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2019-25210"
+      },
+      "timestamp": "2024-05-24T00:38:51.232345+03:00",
+      "products": [
+        {
+          "@id": "pkg:oci/source-controller"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "This CVE has been dismissed by the Helm team https://helm.sh/blog/response-cve-2019-25210/"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2019-25210"
+      },
+      "timestamp": "2024-05-24T00:38:58.404614+03:00",
+      "products": [
+        {
+          "@id": "pkg:oci/helm-controller"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "This CVE has been dismissed by the Helm team https://helm.sh/blog/response-cve-2019-25210/"
+    }
+  ]
 }

--- a/vex/v2.2.json
+++ b/vex/v2.2.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f843e58a33079b9f9344d4b4e72a3dcc0ee7ad51825e087b96692dccaf21f2d8",
+  "author": "flux-enterprise@control-plane.io",
+  "role": "Enterprise Flux Maintainers",
+  "timestamp": "2024-05-23T17:26:04.422544+03:00",
+  "version": 1,
+  "statements": []
+}

--- a/vex/v2.3.json
+++ b/vex/v2.3.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-f843e58a33079b9f9344d4b4e72a3dcc0ee7ad51825e087b96692dccaf21f2d8",
+  "author": "flux-enterprise@control-plane.io",
+  "role": "Enterprise Flux Maintainers",
+  "timestamp": "2024-05-23T17:26:04.422544+03:00",
+  "version": 1,
+  "statements": []
+}


### PR DESCRIPTION
This PR adds Vulnerability Exploitability eXchange documents for each Flux EE release in the [OpenVEX](https://github.com/openvex/spec/blob/v0.2.0/OPENVEX-SPEC.md) format.

Changes:
- Initialise VEX documents for Flux v2.2 and v2.3
- Mark CVE-2019-25210 as `not_affected` in the VEX document corresponding to Flux v2.2.x versions 
- Add a VEX section to the Supply Chain Security docs and explain how customers can use the OpenVEX docs when scanning for CVEs

Closes: #52 