### PR TITLE
Add license scanning

### DIFF
--- a/.github/workflows/scan-license.yaml
+++ b/.github/workflows/scan-license.yaml
@@ -1,0 +1,56 @@
+name: License scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Flux version'
+        required: false
+  push:
+    branches:
+      - 'main'
+      - 'license-*'
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Latest release
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(gh release view --json tagName -q '.tagName')
+          if [ "${{ github.event.inputs.version }}" != "" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Checkout Flux
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          repository: fluxcd/flux2
+          ref: ${{ steps.release.outputs.version }}
+      - name: Setup Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: 'go.mod'
+      - name: Download Flux dependencies
+        run: |         
+          make tidy
+      - name: Setup Trivy
+        run: |
+          sudo apt-get install wget apt-transport-https gnupg lsb-release
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install trivy
+      - name: License report
+        run: |
+          trivy fs -q --format table --scanners  license --severity  UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL ./go.mod
+      - name: License check
+        run: |
+          trivy fs -q --format table --scanners  license --severity  UNKNOWN,HIGH,CRITICAL ./go.mod --exit-code 1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Enterprise Distribution for Flux CD
 
 [![release](https://img.shields.io/github/release/controlplaneio-fluxcd/distribution/all.svg)](https://github.com/controlplaneio-fluxcd/distribution/releases)
-[![Vulnerability scan](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-distribution.yaml/badge.svg)](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-distribution.yaml)
 [![e2e-fips](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/e2e-fips.yaml/badge.svg)](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/e2e-fips.yaml)
+[![Vulnerability scan](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-distribution.yaml/badge.svg)](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-distribution.yaml)
+[![License scan](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-license.yaml/badge.svg)](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-license.yaml)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](#supply-chain-security)
 
 The [ControlPlane](https://control-plane.io) distribution for [Flux CD](https://fluxcd.io)


### PR DESCRIPTION
Scan Flux dependencies, create a report of all licenses and check for CNCF forbidden licenses (strong copyleft and non-OSS).