### PR TITLE
vex: Add exception for CVE-2024-4741, CVE-2023-42365, CVE-2023-42364

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,6 +2,14 @@
 # either because the vulnerable code paths are not used in Flux
 # or because the CVEs have been dismissed by upstream maintainers.
 
+# Alpine CVEs
+# status: not_affected
+# justification: vulnerable_code_not_in_execute_path
+CVE-2024-4741
+CVE-2023-42365
+CVE-2023-42364
+
 # This CVE has been dismissed by the Helm team.
 # https://helm.sh/blog/response-cve-2019-25210/
 CVE-2019-25210
+

--- a/vex/v2.3.json
+++ b/vex/v2.3.json
@@ -4,6 +4,89 @@
   "author": "flux-enterprise@control-plane.io",
   "role": "Enterprise Flux Maintainers",
   "timestamp": "2024-05-23T17:26:04.422544+03:00",
-  "version": 1,
-  "statements": []
+  "last_updated": "2024-06-17T09:15:06.353901+03:00",
+  "version": 2,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2024-4741"
+      },
+      "timestamp": "2024-06-17T09:15:06.353901+03:00",
+      "products": [
+        {
+          "@id": "pkg:apk/alpine/libssl3@3.3.0-r2"
+        },
+        {
+          "@id": "pkg:apk/alpine/libssl3"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3@3.3.0-r2"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable code is not executed by Flux"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-42365"
+      },
+      "timestamp": "2024-06-17T09:15:06.353901+03:00",
+      "products": [
+        {
+          "@id": "pkg:apk/alpine/busybox@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox-binsh@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox-binsh"
+        },
+        {
+          "@id": "pkg:apk/alpine/ssl_client@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/ssl_client"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable code is not executed by Flux"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-42364"
+      },
+      "timestamp": "2024-06-17T09:15:06.353901+03:00",
+      "products": [
+        {
+          "@id": "pkg:apk/alpine/busybox@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox-binsh@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/busybox-binsh"
+        },
+        {
+          "@id": "pkg:apk/alpine/ssl_client@1.36.1-r28"
+        },
+        {
+          "@id": "pkg:apk/alpine/ssl_client"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable code is not executed by Flux"
+    }
+  ]
 }


### PR DESCRIPTION
Mark Alpine CVE-2024-4741, CVE-2023-42365 and CVE-2023-42364 as `vulnerable_code_not_in_execute_path`.