### PR TITLE
Update cluster type documentation to reflect schema

### DIFF
--- a/docs/operator/fluxinstance.md
+++ b/docs/operator/fluxinstance.md
@@ -289,7 +289,7 @@ spec:
 The `.spec.cluster.type` field is optional and specifies the type of the Kubernetes cluster.
 This field is used to enable specific configuration for AKS, EKS, GKE and OpenShift clusters.
 
-The supported values are `kubernetes` (default), `openshift`, `aks`, `eks` and `gke`.
+The supported values are `kubernetes` (default), `openshift`, `azure`, `aws` and `gcp`.
 
 #### Cluster multitenant
 


### PR DESCRIPTION
The [validation spec](https://github.com/controlplaneio-fluxcd/flux-operator/blob/e916d852131d2b19b0beac180e89d5cdd36298d3/api/v1/fluxinstance_types.go#L165) declared for the operator declares these using the cloud vendor names rather than the k8s implementation names.