### PR TITLE
Run conformance tests for ARM Kubernetes clusters

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,7 +27,10 @@ jobs:
           - distroless
         kubernetes:
           - v1.32.0
-    runs-on: ubuntu-latest
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: read
@@ -39,20 +42,29 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+          KUBERNETES_VERSION: ${{ matrix.kubernetes }}
+          FLUX_VERSION: ${{ github.event.inputs.version }}
+          RUNNER_TYPE: ${{ matrix.runner }}
         run: |
           VERSION=$(gh release view --json tagName -q '.tagName')
           
-          branch=${{ github.ref_name }}
           prefix="release-"
-          if [[ "${branch}" =~ ^$prefix.*  ]]; then
-            VERSION=${branch#"$prefix"}
+          if [[ "${BRANCH}" =~ ^$prefix.*  ]]; then
+            VERSION=${BRANCH#"$prefix"}
           fi
           
-          if [ "${{ github.event.inputs.version }}" != "" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [[ "${FLUX_VERSION}" != "" ]]; then
+            VERSION="${FLUX_VERSION}"
+          fi
+          
+          KUBERNETES="${KUBERNETES_VERSION}-amd64"
+          if [[ "${RUNNER_TYPE}" =~ .*arm.* ]]; then
+            KUBERNETES="${KUBERNETES_VERSION}-arm64"
           fi
           
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "kubernetes=${KUBERNETES}" >> $GITHUB_OUTPUT
       - name: Setup Flux
         uses: fluxcd/flux2/action@5350425cdcd5fa015337e09fa502153c0275bd4b #v2.4.0
         with:
@@ -60,9 +72,9 @@ jobs:
       - name: Setup Kubernetes
         uses: helm/kind-action@ae94020eaf628e9b9b9f341a10cc0cdcf5c018fb # v1.11.0
         with:
-          version: v0.24.0
+          version: v0.26.0
           cluster_name: flux
-          node_image: ghcr.io/fluxcd/kindest/node:${{ matrix.kubernetes }}-amd64
+          node_image: ghcr.io/fluxcd/kindest/node:${{ steps.release.outputs.kubernetes }}
       - name: Install Flux
         id: install
         run: |


### PR DESCRIPTION
Add `ubuntu-24.04-arm` runners to the Flux Enterprise conformance tests matrix.

Ref: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ 