### PR TITLE
Split Vulnerability scan into one workflow for alpine, one for distroless and one for operator, and fix Zulip integration

### DIFF
--- a/.github/workflows/scan-alpine.yaml
+++ b/.github/workflows/scan-alpine.yaml
@@ -1,0 +1,42 @@
+name: Vulnerability scan - Alpine
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '00 4 * * 1-5'
+
+jobs:
+  scan:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/scan-controllers.yaml
+    with:
+      check-scan-error: true
+      registry: ghcr.io/controlplaneio-fluxcd/alpine
+    secrets:
+      pull-token: ${{ secrets.GHCR_READONLY }}
+
+  notify-zulip:
+    needs: scan
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Job URL
+      id: job-url
+      run: |
+        url=$(gh run view ${GITHUB_RUN_ID} --repo ${GITHUB_REPO} --json jobs --jq ".jobs[0].url")
+        echo "url: $url"
+        echo url=$url >> $GITHUB_OUTPUT
+      env:
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_REPO: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+      with:
+        email: ${{ secrets.ZULIP_EMAIL }}
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        organization-url: ${{ secrets.ZULIP_ORGANIZATION_URL }}
+        type: stream
+        to: team-flux
+        topic: cve-alerts
+        content: 'Flux Enterprise Alpine CVE alert: ${{ steps.job-url.outputs.url }}'

--- a/.github/workflows/scan-controllers.yaml
+++ b/.github/workflows/scan-controllers.yaml
@@ -17,27 +17,10 @@ on:
         required: false
         type: boolean
         default: true
-      caller-job:
-        description: 'job that called this workflow'
-        required: false
-        type: string
-      variant:
-        description: 'controller variant'
-        type: string
-        required: false
     secrets:
       pull-token:
         description: 'GitHub Container Registry read-only token'
         required: true
-      zulip-email:
-        description: 'Zulip email'
-        required: false
-      zulip-api-key:
-        description: 'Zulip API key'
-        required: false
-      zulip-organization-url:
-        description: 'Zulip organization URL'
-        required: false
 
 jobs:
   trivy:
@@ -168,28 +151,6 @@ jobs:
           echo "image: ${{ steps.images.outputs.irc }}"
           echo "image-automation-controller: ${{ steps.iac.outcome }}"
           echo "image: ${{ steps.images.outputs.iac }}"
-      - name: Get Job URL
-        if: inputs.check-scan-error && (steps.sc.outcome == 'failure' || steps.kc.outcome == 'failure' || steps.hc.outcome == 'failure' || steps.nc.outcome == 'failure' || steps.irc.outcome == 'failure' || steps.iac.outcome == 'failure')
-        id: job-url
-        run: |
-          url=$(gh run view ${GITHUB_RUN_ID} --repo ${GITHUB_REPO} --json jobs --jq ".jobs[] | select(.name == \"${GITHUB_JOB}\") | .url")
-          echo "url: $url"
-          echo url=$url >> $GITHUB_OUTPUT
-        env:
-          GITHUB_JOB: ${{ inputs.caller-job }} / ${{ github.job }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
-        if: inputs.check-scan-error && (steps.sc.outcome == 'failure' || steps.kc.outcome == 'failure' || steps.hc.outcome == 'failure' || steps.nc.outcome == 'failure' || steps.irc.outcome == 'failure' || steps.iac.outcome == 'failure')
-        with:
-          email: ${{ secrets.zulip-email }}
-          api-key: ${{ secrets.zulip-api-key }}
-          organization-url: ${{ secrets.zulip-organization-url }}
-          type: stream
-          to: team-flux
-          topic: cve-alerts
-          content: 'Flux Enterprise ${{ inputs.variant }} CVE alert: ${{ steps.job-url.outputs.url }}'
       - name: Check result
         shell: bash
         if: inputs.check-scan-error && (steps.sc.outcome == 'failure' || steps.kc.outcome == 'failure' || steps.hc.outcome == 'failure' || steps.nc.outcome == 'failure' || steps.irc.outcome == 'failure' || steps.iac.outcome == 'failure')

--- a/.github/workflows/scan-distroless.yaml
+++ b/.github/workflows/scan-distroless.yaml
@@ -1,0 +1,42 @@
+name: Vulnerability scan - Distroless
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '00 4 * * 1-5'
+
+jobs:
+  scan:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/scan-controllers.yaml
+    with:
+      check-scan-error: true
+      registry: ghcr.io/controlplaneio-fluxcd/distroless
+    secrets:
+      pull-token: ${{ secrets.GHCR_READONLY }}
+
+  notify-zulip:
+    needs: scan
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Job URL
+      id: job-url
+      run: |
+        url=$(gh run view ${GITHUB_RUN_ID} --repo ${GITHUB_REPO} --json jobs --jq ".jobs[0].url")
+        echo "url: $url"
+        echo url=$url >> $GITHUB_OUTPUT
+      env:
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_REPO: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+      with:
+        email: ${{ secrets.ZULIP_EMAIL }}
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        organization-url: ${{ secrets.ZULIP_ORGANIZATION_URL }}
+        type: stream
+        to: team-flux
+        topic: cve-alerts
+        content: 'Flux Enterprise Distroless CVE alert: ${{ steps.job-url.outputs.url }}'

--- a/.github/workflows/scan-operator.yaml
+++ b/.github/workflows/scan-operator.yaml
@@ -1,36 +1,12 @@
-name: Vulnerability scan
+name: Vulnerability scan - Operator
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '00 4 * * 1-5'
-
-permissions:
-  contents: read
+  - cron: '00 4 * * 1-5'
 
 jobs:
   scan:
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - alpine
-          - distroless
-    permissions:
-      contents: read
-    uses: ./.github/workflows/scan-controllers.yaml
-    with:
-      check-scan-error: true
-      registry: ghcr.io/controlplaneio-fluxcd/${{ matrix.variant }}
-      caller-job: scan (${{ matrix.variant }})
-      variant: ${{ matrix.variant }}
-    secrets:
-      pull-token: ${{ secrets.GHCR_READONLY }}
-      zulip-email: ${{ secrets.ZULIP_EMAIL }}
-      zulip-api-key: ${{ secrets.ZULIP_API_KEY }}
-      zulip-organization-url: ${{ secrets.ZULIP_ORGANIZATION_URL }}
-
-  scan-operator:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -70,11 +46,10 @@ jobs:
       if: steps.fo.outcome == 'failure'
       id: job-url
       run: |
-        url=$(gh run view ${GITHUB_RUN_ID} --repo ${GITHUB_REPO} --json jobs --jq ".jobs[] | select(.name == \"${GITHUB_JOB}\") | .url")
+        url=$(gh run view ${GITHUB_RUN_ID} --repo ${GITHUB_REPO} --json jobs --jq ".jobs[0].url")
         echo "url: $url"
         echo url=$url >> $GITHUB_OUTPUT
       env:
-        GITHUB_JOB: ${{ github.job }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,5 +67,5 @@ jobs:
       shell: bash
       if: steps.fo.outcome == 'failure'
       run: |
-        echo "One or more controllers have vulnerabilities"
+        echo "Operator has vulnerabilities"
         exit 1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![release](https://img.shields.io/github/release/controlplaneio-fluxcd/distribution/all.svg)](https://github.com/controlplaneio-fluxcd/distribution/releases)
 [![e2e-fips](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/e2e-fips.yaml/badge.svg)](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/e2e-fips.yaml)
-[![Vulnerability scan](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-distribution.yaml/badge.svg)](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-distribution.yaml)
+[![Vulnerability scan](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-distroless.yaml/badge.svg)](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-distroless.yaml)
 [![License scan](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-license.yaml/badge.svg)](https://github.com/controlplaneio-fluxcd/distribution/actions/workflows/scan-license.yaml)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](#supply-chain-security)
 


### PR DESCRIPTION
For some reason I couldn't find, the job URL for notifying Zulip is only found if we run the logic in a top-level job (rather than inside a reusable workflow like before).

Now we can have separate `Vulnerability scan - ${thing}` workflows, which is better because we don't show a big red failed status if only one of those fail e.g. if alpine fails we still wan't to give distroless customers peace of mind.