### PR TITLE
vex: Add exception for CVE-2025-29087

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -8,6 +8,7 @@
 CVE-2024-4741
 CVE-2023-42365
 CVE-2023-42364
+CVE-2025-29087
 
 # This CVE has been dismissed by the Helm team.
 # https://helm.sh/blog/response-cve-2019-25210/

--- a/vex/v2.5.json
+++ b/vex/v2.5.json
@@ -4,8 +4,22 @@
   "author": "flux-enterprise@control-plane.io",
   "role": "Enterprise Flux Maintainers",
   "timestamp": "2024-02-20T17:26:04.422544+03:00",
-  "last_updated": "2024-02-20T17:26:04.422544+03:00",
+  "last_updated": "2025-04-16T12:20:00.000000+01:00",
   "version": 2,
   "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-29087"
+      },
+      "timestamp": "2025-04-16T12:20:00.000000+01:00",
+      "products": [
+        {
+          "@id": "pkg:apk/alpine/sqlite-libs@3.48.0-r0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerable code is not executed by Flux"
+    }
   ]
 }


### PR DESCRIPTION
Mark Alpine CVE-2025-29087 as `vulnerable_code_not_in_execute_path`.