### PR TITLE
Run conformance tests for Kubernetes 1.33.0

### DIFF
--- a/.github/workflows/e2e-fips.yaml
+++ b/.github/workflows/e2e-fips.yaml
@@ -34,6 +34,7 @@ jobs:
           - v1.30.2
           - v1.31.0
           - v1.32.0
+          - v1.33.0
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,7 +26,7 @@ jobs:
           - alpine
           - distroless
         kubernetes:
-          - v1.32.0
+          - v1.33.0
         runner:
           - ubuntu-24.04
           - ubuntu-24.04-arm

--- a/docs/releases/release-v2.5.md
+++ b/docs/releases/release-v2.5.md
@@ -2,10 +2,10 @@
 
 ## Supported Kubernetes Versions
 
-| Distribution | Versions                                          |
-|:-------------|:--------------------------------------------------|
-| Kubernetes   | 1.27 <br>1.28 <br>1.29 <br>1.30 <br>1.31 <br>1.32 |
-| OpenShift    | 4.12 <br>4.13 <br>4.14 <br>4.15 <br>4.16 <br>4.17 |
+| Distribution | Versions                                                   |
+|:-------------|:-----------------------------------------------------------|
+| Kubernetes   | 1.27 <br>1.28 <br>1.29 <br>1.30 <br>1.31 <br>1.32 <br>1.33 |
+| OpenShift    | 4.12 <br>4.13 <br>4.14 <br>4.15 <br>4.16 <br>4.17 <br>4.18 |
 
 ## API Versions
 

--- a/releases/release-v2.5.md
+++ b/releases/release-v2.5.md
@@ -10,10 +10,10 @@
 
 ## Supported Kubernetes Versions
 
-| Distribution | Versions                                          |
-|:-------------|:--------------------------------------------------|
-| Kubernetes   | 1.27 <br>1.28 <br>1.29 <br>1.30 <br>1.31 <br>1.32 |
-| OpenShift    | 4.12 <br>4.13 <br>4.14 <br>4.15 <br>4.16 <br>4.17 |
+| Distribution | Versions                                                   |
+|:-------------|:-----------------------------------------------------------|
+| Kubernetes   | 1.27 <br>1.28 <br>1.29 <br>1.30 <br>1.31 <br>1.32 <br>1.33 |
+| OpenShift    | 4.12 <br>4.13 <br>4.14 <br>4.15 <br>4.16 <br>4.17 <br>4.18 |
 
 ## API Versions
 


### PR DESCRIPTION
Add Kubernetes v1.33.0 to the end-to-end test matrix.

Add Kubernetes 1.33 and OpenShift 4.18 to the Flux Enterprise supported versions.