### PR TITLE
vex: Add exception for CVE-2025-53547

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,6 +10,10 @@ CVE-2023-42365
 CVE-2023-42364
 CVE-2025-29087
 
+# Helm CVEs
+# status: not_affected
+# justification: vulnerable_code_not_in_execute_path
+CVE-2025-53547
 # This CVE has been dismissed by the Helm team.
 # https://helm.sh/blog/response-cve-2019-25210/
 CVE-2019-25210

--- a/vex/v2.6.json
+++ b/vex/v2.6.json
@@ -3,9 +3,51 @@
   "@id": "https://openvex.dev/docs/public/vex-f843e58a33079b9f9344d4b4e72a3dcc0ee7ad51825e087b96692dccaf21f2d8",
   "author": "flux-enterprise@control-plane.io",
   "role": "Enterprise Flux Maintainers",
-  "timestamp": "2024-09-30T17:26:04.422544+03:00",
-  "last_updated": "2024-09-30T17:26:04.422544+03:00",
+  "timestamp": "2025-07-09T09:46:14Z",
+  "last_updated": "2025-07-09T09:46:14Z",
   "version": 2,
   "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-53547"
+      },
+      "timestamp": "2025-07-09T09:46:14Z",
+      "products": [
+        {
+          "@id": "pkg:golang/helm.sh/helm/v3@3.17.3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The affected code is not executed by Flux."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-53547"
+      },
+      "timestamp": "2025-07-09T09:46:14Z",
+      "products": [
+        {
+          "@id": "pkg:oci/source-controller"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The source-controller implements a custom Helm chart downloader that does not use the vulnerable code path in Helm SDK."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-53547"
+      },
+      "timestamp": "2025-07-09T09:46:14Z",
+      "products": [
+        {
+          "@id": "pkg:oci/helm-controller"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The helm-controller does not downloads Helm charts, and the vulnerable code path in Helm SDK is not used."
+    }
   ]
 }


### PR DESCRIPTION
Mark Helm CVE-2025-53547 as `vulnerable_code_not_in_execute_path` ([OpenVEX Specification v0.2.0](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md)).

The affected code is not executed by Flux:
- The source-controller implements a custom Helm chart downloader that does not use the vulnerable code path in Helm SDK. 
- The helm-controller does not downloads Helm charts, and the vulnerable code path in Helm SDK is not used.

Scanner usage example:

```
trivy image ghcr.io/controlplaneio-fluxcd/distroless/source-controller:v1.6.2 --vex ./vex/v2.6.json --show-suppressed
trivy image ghcr.io/controlplaneio-fluxcd/distroless/helm-controller:v1.3.0 --vex ./vex/v2.6.json --show-suppressed
```
