### PR TITLE
Add GitHub Action for migrating Flux manifests

### DIFF
--- a/actions/migrate/README.md
+++ b/actions/migrate/README.md
@@ -1,0 +1,52 @@
+# Migrate Flux Manifests GitHub Action
+
+This GitHub Action can be used to automate the migration of Flux manifests to their latest API version.
+
+## Usage
+
+Example workflow for migrating all the Flux custom resources in the repository:
+
+```yaml
+name: Migrate Flux Manifests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 7 * * 1-5'
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to create branches
+      pull-requests: write # to create PRs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Flux
+        id: setup
+        uses: controlplaneio-fluxcd/distribution/actions/setup@main
+      - name: Migrate manifests
+        uses: controlplaneio-fluxcd/distribution/actions/migrate@main
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: migrate-flux-manifests-${{ steps.setup.outputs.version }}
+          commit-message: |
+            Migrate Flux manifests to ${{ steps.setup.outputs.version }}
+          title: Migrate Flux manifests to ${{ steps.setup.outputs.version }}
+          body: |
+            This PR migrates all the Flux custom resources to their latest API version.
+```
+
+The above workflow will migrate all Flux manifests in the repository to their latest API version
+and create a Pull Request with the changes if any YAML manifest was modified.
+
+## Action Inputs
+
+| Name         | Description                                               | Default               |
+|--------------|-----------------------------------------------------------|-----------------------|
+| `path`       | Path to the directory containing the manifests to migrate | `.`                   |
+| `version`    | Flux major.minor version e.g. 2.7                         | latest stable version |
+| `extensions` | Comma separated list of file extensions to consider       | `.yaml,.yml`          |

--- a/actions/migrate/action.yaml
+++ b/actions/migrate/action.yaml
@@ -1,0 +1,50 @@
+name: Migrate Flux manifests
+description: A GitHub Action for migrating Flux manifests to their latest API version
+author: Stefan Prodan
+branding:
+  color: blue
+  icon: command
+inputs:
+  version:
+    description: "Flux major.minor version e.g. 2.7 (defaults to latest stable release)"
+    required: false
+  path:
+    description: "Path to the directory containing the manifests to migrate"
+    default: "."
+    required: false
+  extensions:
+    description: "Comma separated list of file extensions to consider"
+    default: ".yaml,.yml"
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Check if the Flux CLI is installed
+      shell: bash
+      run: |
+        if ! flux version --client > /dev/null 2>&1; then
+          echo "The Flux CLI is not installed. Please install it first using this GitHub Action:"
+          echo ""
+          echo "  https://github.com/controlplaneio-fluxcd/distribution/tree/main/actions/setup"
+          echo ""
+          exit 1
+        fi
+    - name: "Migrate manifests"
+      shell: bash
+      env:
+        MIGRATE_PATH: ${{ inputs.path }}
+        MIGRATE_EXTENSIONS: ${{ inputs.extensions }}
+        MIGRATE_VERSION: ${{ inputs.version }}
+      run: |
+        PATH_ARG="$MIGRATE_PATH"
+        if [[ -z "$PATH_ARG" ]]; then
+          PATH_ARG="."
+        fi
+        ARGS=(--yes --path "$PATH_ARG")
+        if [[ -n "$MIGRATE_EXTENSIONS" ]]; then
+          ARGS+=(--extensions "$MIGRATE_EXTENSIONS")
+        fi
+        if [[ -n "$MIGRATE_VERSION" ]]; then
+          ARGS+=(--version "$MIGRATE_VERSION")
+        fi
+        flux migrate "${ARGS[@]}"


### PR DESCRIPTION
This GitHub Action can be used to automate the migration of Flux manifests to their latest API version.

## Usage

Example workflow for migrating all the Flux custom resources in the repository:

```yaml
name: Migrate Flux Manifests

on:
  workflow_dispatch:
  schedule:
    - cron: '00 7 * * 1-5'

jobs:
  migrate:
    runs-on: ubuntu-latest
    permissions:
      contents: write # to create branches
      pull-requests: write # to create PRs
    steps:
      - name: Checkout
        uses: actions/checkout@v4
      - name: Setup Flux
        id: setup
        uses: controlplaneio-fluxcd/distribution/actions/setup@main
      - name: Migrate manifests
        uses: controlplaneio-fluxcd/distribution/actions/migrate@main
      - name: Create Pull Request
        uses: peter-evans/create-pull-request@v6
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
          branch: migrate-flux-manifests-${{ steps.setup.outputs.version }}
          commit-message: |
            Migrate Flux manifests to ${{ steps.setup.outputs.version }}
          title: Migrate Flux manifests to ${{ steps.setup.outputs.version }}
          body: |
            This PR migrates all the Flux custom resources to their latest API version.
```

The above workflow will migrate all Flux manifests in the repository to their latest API version
and create a Pull Request with the changes if any YAML manifest was modified.

## Action Inputs

| Name         | Description                                               | Default               |
|--------------|-----------------------------------------------------------|-----------------------|
| `path`       | Path to the directory containing the manifests to migrate | `.`                   |
| `version`    | Flux major.minor version e.g. 2.7                         | latest stable version |
| `extensions` | Comma separated list of file extensions to consider       | `.yaml,.yml`          |