### PR TITLE
Add dex addon (chart + image pins) and update-addons workflow

### DIFF
--- a/.github/workflows/update-addons.sh
+++ b/.github/workflows/update-addons.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Resolve and write chart + image pins for one addon at one
+# addon-version. Called by .github/workflows/update-addons.yaml.
+#
+# Required env:
+#   ADDON           - addon name (today: dex). Drives variant lookup.
+#   ADDON_VERSION   - the addon's release tag (e.g. v2.45.1).
+#   IMAGE_REGISTRY  - ghcr.io/controlplaneio-fluxcd
+#   CHART_REGISTRY  - ghcr.io/controlplaneio-fluxcd/charts
+#
+# Writes:
+#   addons/<addon>/charts/<addon>.yaml             (latest chart from mirror)
+#   addons/<addon>/images/<addon-version>/enterprise-<variant>.yaml
+
+set -eoux pipefail
+
+ADDON="${ADDON}"
+ADDON_VERSION="${ADDON_VERSION}"
+IMAGE_REGISTRY="${IMAGE_REGISTRY}"
+CHART_REGISTRY="${CHART_REGISTRY}"
+
+# Per-addon variant. Today only dex (distroless-fips); future addons
+# extend this case statement.
+case "$ADDON" in
+  dex)
+    IMAGE_VARIANT=distroless-fips
+    ;;
+  *)
+    echo "unknown addon: $ADDON" >&2
+    exit 1
+    ;;
+esac
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+CHART_DIR="${ROOT_DIR}/addons/${ADDON}/charts"
+IMAGES_DIR="${ROOT_DIR}/addons/${ADDON}/images/${ADDON_VERSION}"
+mkdir -p "$CHART_DIR" "$IMAGES_DIR"
+
+# ---- chart pin -------------------------------------------------------------
+# Pick the highest semver tag in the mirror as "latest", then resolve
+# its digest. Helm OCI charts are stored as plain OCI artifacts, so
+# crane reads them.
+CHART_REPO="${CHART_REGISTRY}/${ADDON}"
+CHART_VERSION="$(crane ls "$CHART_REPO" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+CHART_DIGEST="$(crane digest "${CHART_REPO}:${CHART_VERSION}")"
+
+cat >"${CHART_DIR}/${ADDON}.yaml" <<EOF
+chart:
+  name: ${CHART_REPO}
+  version: ${CHART_VERSION}
+  digest: ${CHART_DIGEST}
+EOF
+
+# ---- image pin -------------------------------------------------------------
+IMAGE_REPO="${IMAGE_REGISTRY}/${IMAGE_VARIANT}/${ADDON}"
+IMAGE_DIGEST="$(crane digest "${IMAGE_REPO}:${ADDON_VERSION}")"
+
+cat >"${IMAGES_DIR}/enterprise-${IMAGE_VARIANT}.yaml" <<EOF
+images:
+  - name: ${IMAGE_REPO}
+    newTag: ${ADDON_VERSION}
+    digest: ${IMAGE_DIGEST}
+EOF

--- a/.github/workflows/update-addons.yaml
+++ b/.github/workflows/update-addons.yaml
@@ -1,0 +1,70 @@
+name: Update addons
+
+# Refresh chart and image pins under addons/<addon>/. Mirrors
+# update-images.yaml's dispatch-only model — operator runs this
+# after a CVE round / dependabot bump rebuilds the addon image,
+# or when a new addon-version is published.
+
+on:
+  workflow_dispatch:
+    inputs:
+      addon:
+        description: 'addon name'
+        required: true
+        type: choice
+        default: dex
+        options:
+          - dex
+      version:
+        description: 'addon version (e.g. v2.45.1 for dex)'
+        required: true
+        type: string
+        default: v2.45.1
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_REGISTRY: ghcr.io/controlplaneio-fluxcd
+  CHART_REGISTRY: ghcr.io/controlplaneio-fluxcd/charts
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_READONLY }}
+      - name: Install crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
+      - name: Resolve and write addon pins
+        shell: bash
+        env:
+          ADDON: ${{ inputs.addon }}
+          ADDON_VERSION: ${{ inputs.version }}
+        run: .github/workflows/update-addons.sh
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            Update addon ${{ inputs.addon }} ${{ inputs.version }} pins
+          committer: GitHub <noreply@github.com>
+          signoff: true
+          branch: update-addon-${{ inputs.addon }}-${{ inputs.version }}
+          title: "Update addon ${{ inputs.addon }} ${{ inputs.version }} pins"
+          body: |
+            Refresh chart and image pins for the **${{ inputs.addon }}** addon at version `${{ inputs.version }}`:
+
+            - `addons/${{ inputs.addon }}/charts/${{ inputs.addon }}.yaml` — latest chart version + digest from the mirror.
+            - `addons/${{ inputs.addon }}/images/${{ inputs.version }}/enterprise-<variant>.yaml` — image digest at this addon-version.
+          labels: |
+            area/addons

--- a/addons/dex/charts/dex.yaml
+++ b/addons/dex/charts/dex.yaml
@@ -1,0 +1,7 @@
+# Chart pin for the dex addon. Chart version evolves independently of
+# the dex addon-version, so this lives outside addons/dex/images/<v>/.
+# Maintained by .github/workflows/update-addons.yaml.
+chart:
+  name: ghcr.io/controlplaneio-fluxcd/charts/dex
+  version: 0.0.0
+  digest: sha256:0000000000000000000000000000000000000000000000000000000000000000

--- a/addons/dex/images/v2.45.1/enterprise-distroless-fips.yaml
+++ b/addons/dex/images/v2.45.1/enterprise-distroless-fips.yaml
@@ -1,0 +1,4 @@
+images:
+  - name: ghcr.io/controlplaneio-fluxcd/distroless-fips/dex
+    newTag: v2.45.1
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000


### PR DESCRIPTION
## Layout

Under `addons/<addon>/` — follows the existing `images/` convention so a future addon is a directory copy:

```
addons/dex/
  charts/dex.yaml                                 # chart pin (chart version evolves independently of addon-version)
  images/v2.45.1/enterprise-distroless-fips.yaml  # image pin
```

Dex ships only the **distroless-fips** variant at the latest minor — matches the scope set in [distribution-engine#547](https://github.com/controlplaneio-fluxcd/distribution-engine/pull/547).

## Workflow — `update-addons.yaml` + `update-addons.sh`

- Dispatch-only (mirrors `update-images.yaml`'s model — operator triggers after a CVE round / dependabot bump rebuilds the addon image, or when a new addon-version is published).
- Inputs: `addon` (choice, dex today), `version` (string, e.g. `v2.45.1`).
- Resolves:
  - **Chart** latest version + digest from the OCI mirror (highest semver tag in `ghcr.io/controlplaneio-fluxcd/charts/<addon>`).
  - **Image** digest at the requested addon-version (`ghcr.io/controlplaneio-fluxcd/<variant>/<addon>:<version>`).
- Opens a PR with the refreshed pins (label `area/addons`).

Adding a future addon is a manifest edit (extend the `case "$ADDON"` in `update-addons.sh` for its variant, add it to the `addon:` choice list) plus the directory scaffolding.

## Note on the seed

The four committed yamls carry **placeholder digests (zeros)** — the prod dex image at `ghcr.io/controlplaneio-fluxcd/distroless-fips/dex:v2.45.1` is still being built (post-merge dispatch of `build-stock-dex` in distribution-engine in flight). Run this workflow once the build lands to fill in real digests; that PR can land before this one is merged or right after — either order works.