### PR TITLE
Add mcp addon pins and dynamic addons vulnerability scan

### DIFF
--- a/.github/workflows/scan-addons.yaml
+++ b/.github/workflows/scan-addons.yaml
@@ -1,0 +1,144 @@
+# Vulnerability scan of the published Enterprise addon images.
+#
+# Discovers addons dynamically from the addons/ tree: for every
+# addons/<addon>/, the latest version dir under images/ is selected
+# and every image pinned in its enterprise-*.yaml files is scanned
+# at its published tag. Adding a new addon (or a new addon version)
+# requires no workflow change — the pins are the source of truth.
+#
+# Cron with no inputs scans every addon. Manual dispatch can narrow
+# with the optional addon / severity filters.
+name: Vulnerability scan - Addons
+
+on:
+  workflow_dispatch:
+    inputs:
+      addon:
+        description: 'filter: addon name'
+        required: true
+        type: choice
+        default: all
+        options:
+          - dex
+          - mcp
+          - all
+      severity:
+        description: 'vulnerability severity'
+        required: true
+        type: choice
+        default: CRITICAL,HIGH,MEDIUM,LOW
+        options:
+          - CRITICAL,HIGH,MEDIUM,LOW
+          - CRITICAL,HIGH,MEDIUM
+          - CRITICAL,HIGH
+          - CRITICAL
+  schedule:
+    - cron: '00 5 * * 1-5'
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.find.outputs.targets }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Build (addon, image) matrix from the latest pins
+        id: find
+        shell: bash
+        env:
+          FILTER_ADDON: ${{ inputs.addon }}
+        run: |
+          set -euo pipefail
+          [ "${FILTER_ADDON:-all}" = "all" ] && FILTER_ADDON=""
+          targets="[]"
+          for dir in addons/*/; do
+            addon="$(basename "$dir")"
+            [ -n "$FILTER_ADDON" ] && [ "$addon" != "$FILTER_ADDON" ] && continue
+            latest="$(ls "${dir}images" | sort -V | tail -n1)"
+            for file in "${dir}images/${latest}"/enterprise*.yaml; do
+              count="$(yq '.images | length' "$file")"
+              for i in $(seq 0 $((count - 1))); do
+                name="$(yq ".images[$i].name" "$file")"
+                tag="$(yq ".images[$i].newTag" "$file")"
+                targets="$(jq -c --arg a "$addon" --arg img "${name}:${tag}" \
+                  '. + [{addon: $a, image: $img}]' <<<"$targets")"
+              done
+            done
+          done
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          echo "$targets" | jq .
+
+  scan:
+    needs: discover
+    if: needs.discover.outputs.targets != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.discover.outputs.targets) }}
+    name: scan ${{ matrix.target.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_READONLY }}
+      - name: Resolve trivyignore files
+        id: ignores
+        shell: bash
+        env:
+          ADDON: ${{ matrix.target.addon }}
+        run: |
+          set -euo pipefail
+          files=".trivyignore"
+          if [ -f "addons/${ADDON}/.trivyignore" ]; then
+            files="${files},addons/${ADDON}/.trivyignore"
+          fi
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+      - name: Scan image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ matrix.target.image }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: ${{ inputs.severity || 'CRITICAL,HIGH,MEDIUM,LOW' }}
+          trivyignores: ${{ steps.ignores.outputs.files }}
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GHCR_READONLY }}
+
+  notify-zulip:
+    needs: scan
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Job URL
+      id: job-url
+      run: |
+        url=$(gh run view ${GITHUB_RUN_ID} --repo ${GITHUB_REPO} --json jobs --jq ".jobs[0].url")
+        echo "url: $url"
+        echo url=$url >> $GITHUB_OUTPUT
+      env:
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_REPO: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa # v2.0.1
+      with:
+        email: ${{ secrets.ZULIP_EMAIL }}
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        organization-url: ${{ secrets.ZULIP_ORGANIZATION_URL }}
+        type: stream
+        to: team-flux
+        topic: cve-alerts
+        content: 'Flux Enterprise Addons CVE alert: ${{ steps.job-url.outputs.url }}'

--- a/.github/workflows/update-addons.sh
+++ b/.github/workflows/update-addons.sh
@@ -4,19 +4,19 @@
 # addon-version. Called by .github/workflows/update-addons.yaml.
 #
 # Required env:
-#   ADDON           - addon name (today: dex). Drives variant + upstream lookup.
+#   ADDON           - addon name (dex, mcp). Drives the per-addon artifact table.
 #   IMAGE_REGISTRY  - ghcr.io/controlplaneio-fluxcd
 #   CHART_REGISTRY  - ghcr.io/controlplaneio-fluxcd/charts
 #   GITHUB_TOKEN    - for `gh release view` on the upstream addon repo
 # Optional env (auto-discovered when empty):
-#   ADDON_VERSION   - the addon's release tag (e.g. v2.45.1).
+#   ADDON_VERSION   - the addon's release tag (e.g. v2.45.1 for dex).
 #                     Empty = latest release of the upstream addon repo.
-#   CHART_VERSION   - the helm chart version (e.g. 0.24.0).
+#   CHART_VERSION   - the helm chart version (e.g. 0.24.0 for dex).
 #                     Empty = latest tag pulled by `helm pull`.
 #
 # Writes:
 #   addons/<addon>/charts/<chart-version>/enterprise.yaml
-#   addons/<addon>/images/<addon-version>/enterprise-<variant>.yaml
+#   addons/<addon>/images/<addon-version>/<image-file> (one per image flavor)
 
 set -eoux pipefail
 
@@ -24,11 +24,27 @@ ADDON="${ADDON}"
 IMAGE_REGISTRY="${IMAGE_REGISTRY}"
 CHART_REGISTRY="${CHART_REGISTRY}"
 
-# Per-addon variant + upstream repo. Future addons extend these case statements.
+# Per-addon artifact table. Future addons extend these case statements.
+#
+#   UPSTREAM_REPO      - repo whose latest release defaults ADDON_VERSION
+#   CHART_NAME         - chart repo name under CHART_REGISTRY
+#   IMAGE_REPOS        - image repo paths under IMAGE_REGISTRY, one per flavor
+#   IMAGE_TAG_SUFFIXES - tag suffix appended to ADDON_VERSION, one per flavor
+#   IMAGE_FILES        - pin file name under images/<version>/, one per flavor
 case "$ADDON" in
   dex)
-    IMAGE_VARIANT=distroless-fips
     UPSTREAM_REPO=dexidp/dex
+    CHART_NAME=dex
+    IMAGE_REPOS=( "distroless-fips/dex" )
+    IMAGE_TAG_SUFFIXES=( "" )
+    IMAGE_FILES=( "enterprise-distroless-fips.yaml" )
+    ;;
+  mcp)
+    UPSTREAM_REPO=controlplaneio-fluxcd/flux-mcp-enterprise
+    CHART_NAME=flux-mcp-enterprise
+    IMAGE_REPOS=( "flux-mcp-enterprise" "flux-mcp-enterprise" )
+    IMAGE_TAG_SUFFIXES=( "" "-stdio-readonly" )
+    IMAGE_FILES=( "enterprise-http.yaml" "enterprise-stdio-readonly.yaml" )
     ;;
   *)
     echo "unknown addon: $ADDON" >&2
@@ -36,8 +52,7 @@ case "$ADDON" in
     ;;
 esac
 
-CHART_REPO="${CHART_REGISTRY}/${ADDON}"
-IMAGE_REPO="${IMAGE_REGISTRY}/${IMAGE_VARIANT}/${ADDON}"
+CHART_REPO="${CHART_REGISTRY}/${CHART_NAME}"
 
 # Default ADDON_VERSION to the latest upstream release tag (same pattern as
 # the flux update-images workflow uses `gh release view`).
@@ -77,16 +92,20 @@ spec:
     digest: ${CHART_DIGEST}
 EOF
 
-# ---- image pin -------------------------------------------------------------
-# Same approach as the flux update-images workflow.
-IMAGE_DIGEST="$(docker buildx imagetools inspect "${IMAGE_REPO}:${ADDON_VERSION}" --format '{{json .}}' | jq -r .manifest.digest)"
+# ---- image pins ------------------------------------------------------------
+# Same approach as the flux update-images workflow, once per image flavor.
+for i in "${!IMAGE_REPOS[@]}"; do
+  IMAGE_REPO="${IMAGE_REGISTRY}/${IMAGE_REPOS[$i]}"
+  IMAGE_TAG="${ADDON_VERSION}${IMAGE_TAG_SUFFIXES[$i]}"
+  IMAGE_DIGEST="$(docker buildx imagetools inspect "${IMAGE_REPO}:${IMAGE_TAG}" --format '{{json .}}' | jq -r .manifest.digest)"
 
-cat >"${IMAGES_DIR}/enterprise-${IMAGE_VARIANT}.yaml" <<EOF
+  cat >"${IMAGES_DIR}/${IMAGE_FILES[$i]}" <<EOF
 images:
   - name: ${IMAGE_REPO}
-    newTag: ${ADDON_VERSION}
+    newTag: ${IMAGE_TAG}
     digest: ${IMAGE_DIGEST}
 EOF
+done
 
 # Re-export resolved versions for the calling workflow.
 if [ -n "${GITHUB_OUTPUT:-}" ]; then

--- a/.github/workflows/update-addons.yaml
+++ b/.github/workflows/update-addons.yaml
@@ -15,8 +15,9 @@ on:
         default: dex
         options:
           - dex
+          - mcp
       version:
-        description: 'addon version (e.g. v2.45.1 for dex). Empty = latest tag in the registry.'
+        description: 'addon version (e.g. v2.45.1 for dex, v0.1.0 for mcp). Empty = latest tag in the registry.'
         required: false
         type: string
       chart_version:

--- a/addons/mcp/charts/0.1.0/enterprise.yaml
+++ b/addons/mcp/charts/0.1.0/enterprise.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mcp
+spec:
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-mcp-enterprise
+  ref:
+    tag: 0.1.0
+    digest: sha256:f93783ca084d3b7ec838c77b02b40e0815514ba26412d98306d36712c6e67a99

--- a/addons/mcp/images/v0.1.0/enterprise-http.yaml
+++ b/addons/mcp/images/v0.1.0/enterprise-http.yaml
@@ -1,0 +1,4 @@
+images:
+  - name: ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise
+    newTag: v0.1.0
+    digest: sha256:bf5e936a1e82d1fa590b05cb47469bfcca8306492eecd5f0862a7f13a000fe4d

--- a/addons/mcp/images/v0.1.0/enterprise-stdio-readonly.yaml
+++ b/addons/mcp/images/v0.1.0/enterprise-stdio-readonly.yaml
@@ -1,0 +1,4 @@
+images:
+  - name: ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise
+    newTag: v0.1.0-stdio-readonly
+    digest: sha256:2b32ca6d821ee197390fa8896dce1debe3bcdae0d8f8303538a3c324fd499205

--- a/docs/addons/mcp-stdio.md
+++ b/docs/addons/mcp-stdio.md
@@ -15,6 +15,11 @@ The hardened container images are published at:
 
 - `ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise:<VERSION>-stdio-readonly`
 
+!!! tip "MCP Server latest version"
+
+    The MCP Server container image tag and digest should be kept up to date
+    with the latest release published at [controlplaneio-fluxcd/distribution/addons/mcp](https://github.com/controlplaneio-fluxcd/distribution/tree/main/addons/mcp).
+
 The MCP Server binaries packaged in the multi-arch container images are built
 for Linux amd64/arm64 and are subject to ControlPlane's SLA for CVE remediation and FIPS compliance.
 
@@ -41,13 +46,13 @@ echo $ENTERPRISE_TOKEN | docker login ghcr.io -u flux-enterprise --password-stdi
 On Linux and Windows (WSL2), you can pull the image from the ControlPlane registry with:
 
 ```shell
-docker pull ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise:v0.0.5-stdio-readonly
+docker pull ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise:v0.1.0-stdio-readonly
 ```
 
 Copy the `flux-operator-mcp` binary from the image to a local directory (e.g. `/usr/local/bin`):
 
 ```shell
-docker create --name flux-mcp-extract ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise:v0.0.5-stdio-readonly
+docker create --name flux-mcp-extract ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise:v0.1.0-stdio-readonly
 docker cp flux-mcp-extract:/flux-operator-mcp /usr/local/bin/flux-operator-mcp
 docker rm flux-mcp-extract
 ```
@@ -89,7 +94,7 @@ Add the MCP server to your AI Agent configuration (e.g. `.mcp.json`):
       "run", "--rm", "-i",
       "-v", "/path/to/.kube/config:/home/nonroot/.kube/config:ro",
       "-e", "KUBECONFIG=/home/nonroot/.kube/config",
-      "ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise:v0.0.5-stdio-readonly",
+      "ghcr.io/controlplaneio-fluxcd/flux-mcp-enterprise:v0.1.0-stdio-readonly",
       "serve"
     ]
   }


### PR DESCRIPTION
Onboard the Enterprise Flux MCP server as the `mcp` addon and introduce a single vulnerability scan workflow for all addons:

- `addons/mcp/` — initial pins for v0.1.0: chart `charts/flux-mcp-enterprise` 0.1.0 (OCIRepository patch) and both image flavors (`enterprise-http.yaml` and `enterprise-stdio-readonly.yaml`). Unlike the flux controllers and dex, mcp tags are immutable — CVE fixes ship as new semver patch releases, so new pins land under a new `images/<version>/` dir instead of refreshing digests in place.
- `update-addons.sh` — replaced the variant-derived repo convention with a per-addon artifact table (chart repo name, upstream release repo, one or more image flavors with tag suffixes). The dex path regenerates its existing pins byte-for-byte; the mcp pins in this PR were generated by the updated script.
- `update-addons.yaml` — `mcp` added to the addon choices.
- `scan-addons.yaml` — new scheduled scan (weekdays 5am) that discovers addons dynamically from the `addons/` tree: latest `images/<version>/` dir per addon, every pinned image scanned at its published tag in a matrix. Supports addon/severity dispatch filters, root + optional per-addon `.trivyignore`, and the same Zulip alert path as the flux scans. Adding a future addon needs no workflow change. All three current images scan clean with these settings.