### PR TITLE
Dex docs: move latest version tip up and fix IdP casing

### DIFF
--- a/docs/addons/dex.md
+++ b/docs/addons/dex.md
@@ -1,9 +1,9 @@
 ---
-title: Dex IPD Addon
+title: Dex IdP Addon
 description: Single Sign-On provider for Flux Enterprise
 ---
 
-# Dex IDP
+# Dex IdP
 
 Flux enterprise comes with a hardened [Dex](https://dexidp.io/) distribution that can be used
 to configure Single Sign-On (SSO) for the Flux Web UI and the Flux MCP Server.
@@ -12,6 +12,11 @@ The Dex Helm charts and the hardened container images are published at:
 
 - `ghcr.io/controlplaneio-fluxcd/charts/dex`
 - `ghcr.io/controlplaneio-fluxcd/distroless-fips/dex`
+
+!!! tip "Dex latest version"
+
+    The Dex chart version, container image tag and digest should be kept up to date
+    with the latest release published at [controlplaneio-fluxcd/distribution/addons/dex](https://github.com/controlplaneio-fluxcd/distribution/tree/main/addons/dex).
 
 The Helm charts are built from the upstream Dex [chart repository](https://github.com/dexidp/helm-charts).
 
@@ -80,11 +85,6 @@ spec:
     imagePullSecrets:
       - name: flux-enterprise-auth
 ```
-
-!!! tip "Dex latest version"
-
-    The Dex chart version, container image tag and digest should be kept up to date
-    with the latest release published at [controlplaneio-fluxcd/distribution/addons/dex](https://github.com/controlplaneio-fluxcd/distribution/tree/main/addons/dex).
 
 For a complete example on how to configure Dex for Single Sign-On with Flux Operator,
 please see the [Flux Web UI SSO with Dex documentation](https://fluxoperator.dev/docs/web-ui/sso-dex/).

--- a/docs/distribution/index.md
+++ b/docs/distribution/index.md
@@ -120,7 +120,7 @@ ControlPlane offers enterprise-grade addons that integrate seamlessly with the F
 enabling organizations to enforce identity policies, streamline incident response,
 and operate GitOps at scale.
 
-- [Dex IDP](../addons/dex.md) — hardened Dex providing OIDC-based Single Sign-On for
+- [Dex IdP](../addons/dex.md) — hardened Dex providing OIDC-based Single Sign-On for
   the [Flux Web UI](https://fluxoperator.dev/web-ui/).
 - [Local MCP Server](../addons/mcp-stdio.md) — hardened Flux MCP for AI-assisted
   incident response and GitOps pipeline troubleshooting across environments.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,7 +121,7 @@ nav:
     - Upgrade: distribution/upgrade.md
     - Security: distribution/security.md
     - Flux Addons:
-        - Dex IDP: addons/dex.md
+        - Dex IdP: addons/dex.md
         - Local MCP Server: addons/mcp-stdio.md
     - Guides:
         - Flux Architecture Overview: guides/flux-architecture.md


### PR DESCRIPTION
Two small Dex doc cleanups:

- Move the "Dex latest version" tip right under the published chart/image listing, matching the placement used on the MCP Server addon page, so readers see where the current version lives before copying any configuration.
- Fix "IDP" to the conventional "IdP" casing on the Dex page heading and the distribution overview link.